### PR TITLE
Removes declaration of r10k class from zack/r10k because it is

### DIFF
--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -61,12 +61,6 @@ class role::master {
   file_line { 'github_known_host':
     path => '/root/.ssh/known_hosts',
     line => 'github.com,192.30.252.130 ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==',
-  }->
-  class { 'r10k':
-    remote     => '/opt/puppetlabs/repos/puppet-control.git',
-    basedir    => $::settings::environmentpath,
-    provider   => 'pe_gem',
-    configfile => '/etc/puppetlabs/r10k/r10k.yaml',
   }
 
 }


### PR DESCRIPTION
already installed in PE2015.2 and the default r10k.yaml is
already present.